### PR TITLE
Added gluon About Page and Straight Dope links to all index.html pages

### DIFF
--- a/README.html
+++ b/README.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="./get_started/install.html">Install</a>
 <a class="main-nav-link" href="./tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="./gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="./how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/_static/js/navbar.js
+++ b/_static/js/navbar.js
@@ -1,5 +1,5 @@
 var searchBox = $("#search-input-wrap");
-var TITLE = ['/get_started/', '/tutorials/', '/how_to/', '/api/', '/architecture/'];
+var TITLE = ['/get_started/', '/tutorials/', '/gluon/', '/how_to/', '/api/', '/architecture/'];
 var APIsubMenu;
 $("#burgerMenu").children().each(function () {
     if($(this).children().first().html() == 'API') APIsubMenu = $(this).clone()

--- a/api/c++/index.html
+++ b/api/c++/index.html
@@ -61,6 +61,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>
@@ -83,6 +90,7 @@
 <ul class="dropdown-menu dropdown-menu-right" id="burgerMenu">
 <li><a href="../../get_started/install.html">Install</a></li>
 <li><a href="../../tutorials/index.html">Tutorials</a></li>
+
 <li><a href="../../how_to/index.html">How To</a></li>
 <li class="dropdown-submenu">
 <a href="#" tabindex="-1">API</a>

--- a/api/c++/index.html
+++ b/api/c++/index.html
@@ -90,7 +90,7 @@
 <ul class="dropdown-menu dropdown-menu-right" id="burgerMenu">
 <li><a href="../../get_started/install.html">Install</a></li>
 <li><a href="../../tutorials/index.html">Tutorials</a></li>
-
+<li><a href="../../gluon/index.html">Gluon</a></li>
 <li><a href="../../how_to/index.html">How To</a></li>
 <li class="dropdown-submenu">
 <a href="#" tabindex="-1">API</a>

--- a/api/c++/index.html
+++ b/api/c++/index.html
@@ -90,7 +90,6 @@
 <ul class="dropdown-menu dropdown-menu-right" id="burgerMenu">
 <li><a href="../../get_started/install.html">Install</a></li>
 <li><a href="../../tutorials/index.html">Tutorials</a></li>
-<li><a href="../../gluon/index.html">Gluon</a></li>
 <li><a href="../../how_to/index.html">How To</a></li>
 <li class="dropdown-submenu">
 <a href="#" tabindex="-1">API</a>

--- a/api/julia/index.html
+++ b/api/julia/index.html
@@ -61,6 +61,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>
@@ -83,6 +90,7 @@
 <ul class="dropdown-menu dropdown-menu-right" id="burgerMenu">
 <li><a href="../../get_started/install.html">Install</a></li>
 <li><a href="../../tutorials/index.html">Tutorials</a></li>
+
 <li><a href="../../how_to/index.html">How To</a></li>
 <li class="dropdown-submenu">
 <a href="#" tabindex="-1">API</a>

--- a/api/perl/index.html
+++ b/api/perl/index.html
@@ -61,6 +61,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/perl/io.html
+++ b/api/perl/io.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">   
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>
@@ -81,6 +88,15 @@
 <ul class="dropdown-menu dropdown-menu-right" id="burgerMenu">
 <li><a href="../../get_started/install.html">Install</a></li>
 <li><a href="../../tutorials/index.html">Tutorials</a></li>
+<li class="dropdown-submenu">
+<a href="#" tabindex="-1">Gluon</a>
+<ul class="dropdown-menu">
+<li><a href="../../gluon/index.html" tabindex="-1">About</a>
+</li>
+<li><a href="http://gluon.mxnet.io/" tabindex="-1">The Straight Dope</a>
+</li>
+</ul>
+</li>
 <li><a href="../../how_to/index.html">How To</a></li>
 <li class="dropdown-submenu">
 <a href="#" tabindex="-1">API</a>

--- a/api/perl/kvstore.html
+++ b/api/perl/kvstore.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/perl/module.html
+++ b/api/perl/module.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/perl/ndarray.html
+++ b/api/perl/ndarray.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/perl/symbol.html
+++ b/api/perl/symbol.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/python/autograd.html
+++ b/api/python/autograd.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/python/callback.html
+++ b/api/python/callback.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/python/gluon.html
+++ b/api/python/gluon.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/python/image.html
+++ b/api/python/image.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/python/index.html
+++ b/api/python/index.html
@@ -61,6 +61,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/python/io.html
+++ b/api/python/io.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/python/kvstore.html
+++ b/api/python/kvstore.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/python/metric.html
+++ b/api/python/metric.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/python/model.html
+++ b/api/python/model.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/python/module.html
+++ b/api/python/module.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/python/ndarray.html
+++ b/api/python/ndarray.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/python/optimization.html
+++ b/api/python/optimization.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/python/rnn.html
+++ b/api/python/rnn.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/python/symbol.html
+++ b/api/python/symbol.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/python/symbol_in_pictures.html
+++ b/api/python/symbol_in_pictures.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/r/index.html
+++ b/api/r/index.html
@@ -61,6 +61,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/scala/index.html
+++ b/api/scala/index.html
@@ -61,6 +61,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/scala/io.html
+++ b/api/scala/io.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/scala/kvstore.html
+++ b/api/scala/kvstore.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/scala/model.html
+++ b/api/scala/model.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/scala/module.html
+++ b/api/scala/module.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/scala/ndarray.html
+++ b/api/scala/ndarray.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/scala/symbol.html
+++ b/api/scala/symbol.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/api/scala/symbol_in_pictures.html
+++ b/api/scala/symbol_in_pictures.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/architecture/index.html
+++ b/architecture/index.html
@@ -61,6 +61,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/architecture/note_data_loading.html
+++ b/architecture/note_data_loading.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/architecture/note_engine.html
+++ b/architecture/note_engine.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/architecture/note_memory.html
+++ b/architecture/note_memory.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/architecture/overview.html
+++ b/architecture/overview.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/architecture/program_model.html
+++ b/architecture/program_model.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/architecture/release_note_0_9.html
+++ b/architecture/release_note_0_9.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/architecture/rnn_interface.html
+++ b/architecture/rnn_interface.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/community/contribute.html
+++ b/community/contribute.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/community/index.html
+++ b/community/index.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/community/mxnet_channels.html
+++ b/community/mxnet_channels.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/genindex.html
+++ b/genindex.html
@@ -60,6 +60,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="./get_started/install.html">Install</a>
 <a class="main-nav-link" href="./tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="./how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/get_started/amazonlinux_setup.html
+++ b/get_started/amazonlinux_setup.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/get_started/build_from_source.html
+++ b/get_started/build_from_source.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/get_started/centos_setup.html
+++ b/get_started/centos_setup.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/get_started/index.html
+++ b/get_started/index.html
@@ -61,6 +61,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/get_started/install.html
+++ b/get_started/install.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/get_started/osx_setup.html
+++ b/get_started/osx_setup.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/get_started/raspbian_setup.html
+++ b/get_started/raspbian_setup.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/get_started/tx2_setup.html
+++ b/get_started/tx2_setup.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/get_started/ubuntu_setup.html
+++ b/get_started/ubuntu_setup.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/get_started/why_mxnet.html
+++ b/get_started/why_mxnet.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/get_started/windows_setup.html
+++ b/get_started/windows_setup.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/gluon/index.html
+++ b/gluon/index.html
@@ -166,10 +166,9 @@
 <div class="content">
   <div class="section" id="about-gluon">
 <span id="about-gluon"></span><h1>About Gluon<a class="headerlink" href="#about-gluon" title="Permalink to this headline">¶</a></h1>
-<p>MXNet’s Gluon library provides a high-level interface that makes it easy to prototype, train, and deploy deep learning models. It offers higher-level abstractions for predefined layers, loss functions, and optimizers and provides the flexibility of imperative frameworks, which are more intuitive to work with and easier to debug. In addition, it enables building dynamic neural networks on the fly. When speed becomes more important than flexibility, Gluon can also compile your networks with a single line of code, offering optimized performance and memory usage. You can easily get started with the Gluon interface using <a href="http://gluon.mxnet.io/">this extensive set of tutorials, documentation, and examples.</a></p>
+<p>The new Gluon interface is available as a library in Apache MXNet and allows developers of all skill levels to prototype, build, and train deep learning models. This interface greatly simplifies the process of creating deep learning models without sacrificing training speed. You can easily get started with the Gluon interface using <a href="http://gluon.mxnet.io/">this extensive set of tutorials, documentation, and examples.</a></p>
 
-<!-- START - Linux Python CPU Installation Instructions -->
-<strong>Here is a bit more on what Gluon’s four major advantages:</strong>
+<strong>Here are Gluon’s four major advantages:</strong>
 <p>
 <p><strong>Simple, Easy-to-Understand Code</strong></p>
 <p>In Gluon, neural networks can be defined using simple, clear, concise code – this is easier to learn and understand. You get a set of plug-and-play neural network building blocks, including predefined layers, optimizers, and initializers. These abstract away many of the complicated underlying implementation details. Below you see that you can define a neural network with just a few lines of code:</p>

--- a/gluon/index.html
+++ b/gluon/index.html
@@ -5,12 +5,12 @@
 <meta charset="utf-8"/>
 <meta content="IE=edge" http-equiv="X-UA-Compatible"/>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
-<title>Tutorials — mxnet  documentation</title>
+<title>Installing MXNet — mxnet  documentation</title>
 <link crossorigin="anonymous" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" rel="stylesheet"/>
 <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" rel="stylesheet"/>
-<link href="../_static/basic.css" rel="stylesheet" type="text/css">
-<link href="../_static/pygments.css" rel="stylesheet" type="text/css">
-<link href="../_static/mxnet.css" rel="stylesheet" type="text/css"/>
+<link href="../_static/basic.css" rel="stylesheet" type="text/css"/>
+<link href="../_static/pygments.css" rel="stylesheet" type="text/css"/>
+<link href="../_static/mxnet.css" rel="stylesheet" type="text/css">
 <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
@@ -48,10 +48,8 @@
 <!-- -->
 <!-- <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script> -->
 <!-- -->
-<link href="basic/ndarray.html" rel="next" title="NDArray - Imperative tensor operations on CPU/GPU">
-<link href="../architecture/index.html" rel="prev" title="MXNet Architecture"/>
-<link href="https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/mxnet-icon.png" rel="icon" type="image/png"/>
-</link></link></link></head>
+<link href="https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/mxnet-icon.png" rel="icon" type="image/png">
+</link></link></head>
 <body role="document"><div class="navbar navbar-fixed-top">
 <div class="container" id="navContainer">
 <div class="innder" id="header-inner">
@@ -83,7 +81,7 @@
 <a class="main-nav-link" href="../architecture/index.html">Architecture</a>
 <!-- <a class="main-nav-link" href="../community/index.html">Community</a> -->
 <a class="main-nav-link" href="https://github.com/dmlc/mxnet">Github</a>
-<span id="dropdown-menu-position-anchor-version" style="position: relative"><a href="#" class="main-nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="true">Versions(0.11.0)<span class="caret"></span></a><ul id="package-dropdown-menu" class="dropdown-menu"><li><a class="main-nav-link" href=https://mxnet.incubator.apache.org/>0.11.0</a></li><li><a class="main-nav-link" href=https://mxnet.incubator.apache.org/versions/0.11.0.rc3/index.html>0.11.0.rc3</a></li><li><a class="main-nav-link" href=https://mxnet.incubator.apache.org/versions/master/index.html>master</a></li></ul></span></nav>
+<span id="dropdown-menu-position-anchor-version" style="position: relative"><a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Versions(0.11.0)<span class="caret"></span></a><ul class="dropdown-menu" id="package-dropdown-menu"><li><a class="main-nav-link" href="https://mxnet.incubator.apache.org/">0.11.0</a></li><li><a class="main-nav-link" href="https://mxnet.incubator.apache.org/versions/0.11.0.rc3/index.html">0.11.0.rc3</a></li><li><a class="main-nav-link" href="https://mxnet.incubator.apache.org/versions/master/index.html">master</a></li></ul></span></nav>
 <script> function getRootPath(){ return "../" } </script>
 <div class="burgerIcon dropdown">
 <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button">☰</a>
@@ -110,7 +108,7 @@
 </li>
 <li><a href="../architecture/index.html">Architecture</a></li>
 <li><a class="main-nav-link" href="https://github.com/dmlc/mxnet">Github</a></li>
-<li id="dropdown-menu-position-anchor-version-mobile" class="dropdown-submenu" style="position: relative"><a href="#" tabindex="-1">Versions(0.11.0)</a><ul class="dropdown-menu"><li><a tabindex="-1" href=https://mxnet.incubator.apache.org/>0.11.0</a></li><li><a tabindex="-1" href=https://mxnet.incubator.apache.org/versions/0.11.0.rc3/index.html>0.11.0.rc3</a></li><li><a tabindex="-1" href=https://mxnet.incubator.apache.org/versions/master/index.html>master</a></li></ul></li></ul>
+<li class="dropdown-submenu" id="dropdown-menu-position-anchor-version-mobile" style="position: relative"><a href="#" tabindex="-1">Versions(0.11.0)</a><ul class="dropdown-menu"><li><a href="https://mxnet.incubator.apache.org/" tabindex="-1">0.11.0</a></li><li><a href="https://mxnet.incubator.apache.org/versions/0.11.0.rc3/index.html" tabindex="-1">0.11.0.rc3</a></li><li><a href="https://mxnet.incubator.apache.org/versions/master/index.html" tabindex="-1">master</a></li></ul></li></ul>
 </div>
 <div class="plusIcon dropdown">
 <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button"><span aria-hidden="true" class="glyphicon glyphicon-plus"></span></a>
@@ -122,8 +120,8 @@
 <i class="glyphicon glyphicon-search"></i>
 <input class="form-control" name="q" placeholder="Search" type="text"/>
 </div>
-<input name="check_keywords" type="hidden" value="yes">
-<input name="area" type="hidden" value="default"/>
+<input name="check_keywords" type="hidden" value="yes"/>
+<input name="area" type="hidden" value="default">
 </input></form>
 <div id="search-preview"></div>
 </div>
@@ -152,7 +150,7 @@
 <div class="row">
 <div aria-label="main navigation" class="sphinxsidebar leftsidebar" role="navigation">
 <div class="sphinxsidebarwrapper">
-<ul class="current">
+<ul>
 <li class="toctree-l1"><a class="reference internal" href="../api/python/index.html">Python Documents</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../api/r/index.html">R Documents</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../api/julia/index.html">Julia Documents</a></li>
@@ -161,67 +159,58 @@
 <li class="toctree-l1"><a class="reference internal" href="../api/perl/index.html">Perl Documents</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../how_to/index.html">HowTo Documents</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../architecture/index.html">System Documents</a></li>
-<li class="toctree-l1 current"><a class="current reference internal" href="">Tutorials</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="#python">Python</a><ul>
-<li class="toctree-l3"><a class="reference internal" href="#basic">Basic</a><ul>
-<li class="toctree-l4"><a class="reference internal" href="basic/ndarray.html">NDArray - Imperative tensor operations on CPU/GPU</a></li>
-<li class="toctree-l4"><a class="reference internal" href="basic/symbol.html">Symbol - Neural network graphs and auto-differentiation</a></li>
-<li class="toctree-l4"><a class="reference internal" href="basic/module.html">Module - Neural network training and inference</a></li>
-<li class="toctree-l4"><a class="reference internal" href="basic/data.html">Iterators - Loading data</a></li>
-</ul>
-</li>
-<li class="toctree-l3"><a class="reference internal" href="#training-and-inference">Training and Inference</a><ul>
-<li class="toctree-l4"><a class="reference internal" href="python/linear-regression.html">Linear Regression</a></li>
-<li class="toctree-l4"><a class="reference internal" href="python/mnist.html">Handwritten Digit Recognition</a></li>
-<li class="toctree-l4"><a class="reference internal" href="python/predict_image.html">Predict with pre-trained models</a></li>
-<li class="toctree-l4"><a class="reference internal" href="vision/large_scale_classification.html">Large Scale Image Classification</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li class="toctree-l2"><a class="reference internal" href="#contributing-tutorials">Contributing Tutorials</a></li>
-</ul>
-</li>
+<li class="toctree-l1"><a class="reference internal" href="../tutorials/index.html">Tutorials</a></li>
 </ul>
 </div>
 </div>
 <div class="content">
-<div class="section" id="tutorials">
-<span id="tutorials"></span><h1>Tutorials<a class="headerlink" href="#tutorials" title="Permalink to this headline">¶</a></h1>
-<p>These tutorials introduce a few fundamental concepts in deep learning and how to implement them in <em>MXNet</em>. The <em>Basics</em> section contains tutorials on manipulating arrays, building networks, loading/preprocessing data, etc. The <em>Training and Inference</em> section talks about implementing Linear Regression, training a Handwritten digit classifier using MLP and CNN, running inferences using a pre-trained model, and lastly, efficiently training a large scale image classifier.</p>
-<p><strong>Note:</strong> We are working on a set of tutorials for the new imperative interface called Gluon. A preview version is hosted at <a class="reference external" href="http://gluon.mxnet.io">gluon.mxnet.io</a>.</p>
-<div class="section" id="python">
-<span id="python"></span><h2>Python<a class="headerlink" href="#python" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="basic">
-<span id="basic"></span><h3>Basic<a class="headerlink" href="#basic" title="Permalink to this headline">¶</a></h3>
-<div class="toctree-wrapper compound">
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="basic/ndarray.html">NDArray - Imperative tensor operations on CPU/GPU</a></li>
-<li class="toctree-l1"><a class="reference internal" href="basic/symbol.html">Symbol - Neural network graphs and auto-differentiation</a></li>
-<li class="toctree-l1"><a class="reference internal" href="basic/module.html">Module - Neural network training and inference</a></li>
-<li class="toctree-l1"><a class="reference internal" href="basic/data.html">Iterators - Loading data</a></li>
-</ul>
+  <div class="section" id="about-gluon">
+<span id="about-gluon"></span><h1>About Gluon<a class="headerlink" href="#about-gluon" title="Permalink to this headline">¶</a></h1>
+<p>MXNet’s Gluon library provides a high-level interface that makes it easy to prototype, train, and deploy deep learning models. It offers higher-level abstractions for predefined layers, loss functions, and optimizers and provides the flexibility of imperative frameworks, which are more intuitive to work with and easier to debug. In addition, it enables building dynamic neural networks on the fly. When speed becomes more important than flexibility, Gluon can also compile your networks with a single line of code, offering optimized performance and memory usage. You can easily get started with the Gluon interface using <a href="http://gluon.mxnet.io/">this extensive set of tutorials, documentation, and examples.</a></p>
+
+<!-- START - Linux Python CPU Installation Instructions -->
+<strong>Here is a bit more on what Gluon’s four major advantages:</strong>
+<p>
+<p><strong>Simple, Easy-to-Understand Code</strong></p>
+<p>In Gluon, neural networks can be defined using simple, clear, concise code – this is easier to learn and understand. You get a set of plug-and-play neural network building blocks, including predefined layers, optimizers, and initializers. These abstract away many of the complicated underlying implementation details. Below you see that you can define a neural network with just a few lines of code:</p>
+<div class="highlight-bash"><div class="highlight"><pre><span></span><span class="nv">net</span> <span class="o">=</span> gluon.nn.Sequential<span class="o">()</span>
+<span class="c1"># When instantiated, Sequential stores a chain of neural network layers. </span>
+<span class="c1"># Once presented with data, Sequential executes each layer in turn, using </span>
+<span class="c1"># the output of one layer as the input for the next</span>
+with net.name_scope<span class="o">()</span>:
+    net.add<span class="o">(</span>gluon.nn.Dense<span class="o">(</span><span class="m">256</span>, <span class="nv">activation</span><span class="o">=</span><span class="s2">&quot;relu&quot;</span><span class="o">))</span> <span class="c1"># 1st layer (256 nodes)</span>
+    net.add<span class="o">(</span>gluon.nn.Dense<span class="o">(</span><span class="m">256</span>, <span class="nv">activation</span><span class="o">=</span><span class="s2">&quot;relu&quot;</span><span class="o">))</span> <span class="c1"># 2nd hidden layer</span>
+    net.add<span class="o">(</span>gluon.nn.Dense<span class="o">(</span>num_outputs<span class="o">))</span>
+</pre></div>
+</div>
+
+<p><strong>Flexible, Imperative Structure</strong></p>
+<p>The Gluon interface supports a fully imperative way of working with neural networks, offering more familiarity and flexibility. Many familiar programming languages like Python are imperative, and imperative programs execute code line by line versus waiting for a code compilation step prior to executing any code. With Gluon, you can easily experiment and prototype with neural networks. Debugging is also easier with Gluon because you can identify the exact line of code causing an issue. Central to enabling this are the MXNet <em>autograd</em> package and the Gluon trainer method. You can define a model training algorithm that consists of a for loop, using <em>autograd</em> to automatically calculate derivatives of the model’s parameters and <em>trainer</em> to optimize them.</p>
+<p><strong>Dynamic Graphs</strong></p>
+<p>In certain scenarios, the neural network model may need to change in shape and size during model training. This is necessary in particular when the data fed into the neural network is variable, which is common in Natural Language Processing (NLP) where each sentence inputted can be of different length. With Gluon, neural network definition can be dynamic, meaning you can build it on the fly, with any structure you want, and using any of Python’s native control flow. In the below code snippet, you can see how to incorporate a loop in each forward iteration of model training.</p>
+<div class="highlight-bash"><div class="highlight"><pre><span></span>def forward<span class="o">(</span>self, F, inputs, tree<span class="o">)</span>:
+    <span class="nv">children_outputs</span> <span class="o">=</span> <span class="o">[</span>self.forward<span class="o">(</span>F, inputs, child<span class="o">)</span>
+                        <span class="k">for</span> child in tree.children<span class="o">]</span>
+    <span class="c1">#Recursively builds the neural network based on each input sentence’s</span>
+    <span class="c1">#syntactic structure during the model definition and training process</span>
+    …
+</pre></div>
+</div>
+<p><strong>High Performance</strong></p>
+<p>When speed becomes more important than flexibility, the Gluon interface enables you to easily cache the neural network model to achieve high performance. This only requires a small tweak when you set up your neural network – this is after you are done with your prototype and ready to test it on a larger dataset. Instead of using <em>Sequential</em> (as shown above) to stack the neural network layers, you must use <em>HybridSequential</em>. Its functionality is the same as <em>Sequential</em>, but it lets you call down to the underlying optimized engine to express some or all of your model’s architecture.</p>
+<div class="highlight-bash"><div class="highlight"><pre><span></span><span class="nv">net</span> <span class="o">=</span> nn.HybridSequential<span class="o">()</span>
+with net.name_scope<span class="o">()</span>:
+    net.add<span class="o">(</span>nn.Dense<span class="o">(</span><span class="m">256</span>, <span class="nv">activation</span><span class="o">=</span><span class="s2">&quot;relu&quot;</span><span class="o">))</span>
+    net.add<span class="o">(</span>nn.Dense<span class="o">(</span><span class="m">128</span>, <span class="nv">activation</span><span class="o">=</span><span class="s2">&quot;relu&quot;</span><span class="o">))</span>
+    net.add<span class="o">(</span>nn.Dense<span class="o">(</span><span class="m">2</span><span class="o">))</span>
+</pre></div>
+</div>
+<p>Next, to compile and optimize the HybridSequential, we can then call its hybridize method:</p>
+<div class="highlight-bash"><div class="highlight"><pre><span></span>net.hybridize<span class="o">()</span>
+</pre></div>
 </div>
 </div>
-<div class="section" id="training-and-inference">
-<span id="training-and-inference"></span><h3>Training and Inference<a class="headerlink" href="#training-and-inference" title="Permalink to this headline">¶</a></h3>
-<div class="toctree-wrapper compound">
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="python/linear-regression.html">Linear Regression</a></li>
-<li class="toctree-l1"><a class="reference internal" href="python/mnist.html">Handwritten Digit Recognition</a></li>
-<li class="toctree-l1"><a class="reference internal" href="python/predict_image.html">Predict with pre-trained models</a></li>
-<li class="toctree-l1"><a class="reference internal" href="vision/large_scale_classification.html">Large Scale Image Classification</a></li>
-</ul>
-</div>
-<p><br/>
-More tutorials and examples are available in the GitHub <a class="reference external" href="https://github.com/dmlc/mxnet/tree/master/example">repository</a>.</p>
-</div>
-</div>
-<div class="section" id="contributing-tutorials">
-<span id="contributing-tutorials"></span><h2>Contributing Tutorials<a class="headerlink" href="#contributing-tutorials" title="Permalink to this headline">¶</a></h2>
-<p>Want to contribute an MXNet tutorial? To get started, download the <a class="reference external" href="https://github.com/dmlc/mxnet/tree/master/example/MXNetTutorialTemplate.ipynb">tutorial template</a>.</p>
-</div>
-</div>
+
 <div class="container">
 <div class="footer">
 <p> </p>
@@ -232,15 +221,9 @@ More tutorials and examples are available in the GitHub <a class="reference exte
 <div class="sphinxsidebarwrapper">
 <h3><a href="../index.html">Table Of Contents</a></h3>
 <ul>
-<li><a class="reference internal" href="#">Tutorials</a><ul>
-<li><a class="reference internal" href="#python">Python</a><ul>
-<li><a class="reference internal" href="#basic">Basic</a></li>
-<li><a class="reference internal" href="#training-and-inference">Training and Inference</a></li>
-</ul>
-</li>
-<li><a class="reference internal" href="#contributing-tutorials">Contributing Tutorials</a></li>
-</ul>
-</li>
+<li><a class="reference internal" href="#">Installing MXNet</a></li>
+<li><a class="reference internal" href="#validate-mxnet-installation">Validate MXNet Installation</a></li>
+<li><a class="reference internal" href="#download-source-package">Download Source Package</a></li>
 </ul>
 </div>
 </div>

--- a/how_to/bucketing.html
+++ b/how_to/bucketing.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/how_to/caffe.html
+++ b/how_to/caffe.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/how_to/cloud.html
+++ b/how_to/cloud.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/how_to/develop_and_hack.html
+++ b/how_to/develop_and_hack.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/how_to/env_var.html
+++ b/how_to/env_var.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/how_to/faq.html
+++ b/how_to/faq.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/how_to/finetune.html
+++ b/how_to/finetune.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/how_to/index.html
+++ b/how_to/index.html
@@ -61,6 +61,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/how_to/model_parallel_lstm.html
+++ b/how_to/model_parallel_lstm.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/how_to/multi_devices.html
+++ b/how_to/multi_devices.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/how_to/new_op.html
+++ b/how_to/new_op.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/how_to/nnpack.html
+++ b/how_to/nnpack.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/how_to/perf.html
+++ b/how_to/perf.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/how_to/recordio.html
+++ b/how_to/recordio.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/how_to/s3_integration.html
+++ b/how_to/s3_integration.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/how_to/smart_device.html
+++ b/how_to/smart_device.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/how_to/torch.html
+++ b/how_to/torch.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/how_to/visualize_graph.html
+++ b/how_to/visualize_graph.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/index.html
+++ b/index.html
@@ -58,6 +58,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="./get_started/install.html">Install</a>
 <a class="main-nav-link" href="./tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="./how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/model_zoo/index.html
+++ b/model_zoo/index.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/py-modindex.html
+++ b/py-modindex.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="./get_started/install.html">Install</a>
 <a class="main-nav-link" href="./tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="./gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="./how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/search.html
+++ b/search.html
@@ -65,6 +65,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="./get_started/install.html">Install</a>
 <a class="main-nav-link" href="./tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="./gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="./how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/basic/data.html
+++ b/tutorials/basic/data.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/basic/image_io.html
+++ b/tutorials/basic/image_io.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/basic/module.html
+++ b/tutorials/basic/module.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/basic/ndarray.html
+++ b/tutorials/basic/ndarray.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/basic/record_io.html
+++ b/tutorials/basic/record_io.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/basic/symbol.html
+++ b/tutorials/basic/symbol.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/c++/basics.html
+++ b/tutorials/c++/basics.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/embedded/wine_detector.html
+++ b/tutorials/embedded/wine_detector.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/general_ml/recommendation_systems.html
+++ b/tutorials/general_ml/recommendation_systems.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/gluon/autograd.html
+++ b/tutorials/gluon/autograd.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/gluon/customop.html
+++ b/tutorials/gluon/customop.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/gluon/gluon.html
+++ b/tutorials/gluon/gluon.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/gluon/hybrid.html
+++ b/tutorials/gluon/hybrid.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/gluon/mnist.html
+++ b/tutorials/gluon/mnist.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/gluon/ndarray.html
+++ b/tutorials/gluon/ndarray.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/nlp/cnn.html
+++ b/tutorials/nlp/cnn.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/nlp/nce_loss.html
+++ b/tutorials/nlp/nce_loss.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/nlp/rnn.html
+++ b/tutorials/nlp/rnn.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/python/kvstore.html
+++ b/tutorials/python/kvstore.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/python/linear-regression.html
+++ b/tutorials/python/linear-regression.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/python/matrix_factorization.html
+++ b/tutorials/python/matrix_factorization.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/python/mnist.html
+++ b/tutorials/python/mnist.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/python/predict_image.html
+++ b/tutorials/python/predict_image.html
@@ -62,6 +62,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/r/CallbackFunction.html
+++ b/tutorials/r/CallbackFunction.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/r/CallbackFunctionTutorial.html
+++ b/tutorials/r/CallbackFunctionTutorial.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/r/CustomIterator.html
+++ b/tutorials/r/CustomIterator.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/r/CustomIteratorTutorial.html
+++ b/tutorials/r/CustomIteratorTutorial.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/r/CustomLossFunction.html
+++ b/tutorials/r/CustomLossFunction.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/r/charRnnModel.html
+++ b/tutorials/r/charRnnModel.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/r/classifyRealImageWithPretrainedModel.html
+++ b/tutorials/r/classifyRealImageWithPretrainedModel.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/r/fiveMinutesNeuralNetwork.html
+++ b/tutorials/r/fiveMinutesNeuralNetwork.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/r/index.html
+++ b/tutorials/r/index.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/r/mnistCompetition.html
+++ b/tutorials/r/mnistCompetition.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/r/ndarray.html
+++ b/tutorials/r/ndarray.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/r/symbol.html
+++ b/tutorials/r/symbol.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/scala/char_lstm.html
+++ b/tutorials/scala/char_lstm.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/scala/mnist.html
+++ b/tutorials/scala/mnist.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/scala/mxnet_scala_on_intellij.html
+++ b/tutorials/scala/mxnet_scala_on_intellij.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/speech_recognition/baidu_warp_ctc.html
+++ b/tutorials/speech_recognition/baidu_warp_ctc.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/speech_recognition/speech_lstm.html
+++ b/tutorials/speech_recognition/speech_lstm.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/unsupervised_learning/auto_encoders.html
+++ b/tutorials/unsupervised_learning/auto_encoders.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/unsupervised_learning/gan.html
+++ b/tutorials/unsupervised_learning/gan.html
@@ -59,6 +59,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/tutorials/vision/large_scale_classification.html
+++ b/tutorials/vision/large_scale_classification.html
@@ -61,6 +61,13 @@
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/README.html
+++ b/versions/0.11.0.rc3/README.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="./get_started/install.html">Install</a>
 <a class="main-nav-link" href="./tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="./gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="./how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/c++/index.html
+++ b/versions/0.11.0.rc3/api/c++/index.html
@@ -138,6 +138,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/julia/index.html
+++ b/versions/0.11.0.rc3/api/julia/index.html
@@ -138,6 +138,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/perl/index.html
+++ b/versions/0.11.0.rc3/api/perl/index.html
@@ -138,6 +138,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/perl/io.html
+++ b/versions/0.11.0.rc3/api/perl/io.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/perl/kvstore.html
+++ b/versions/0.11.0.rc3/api/perl/kvstore.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/perl/module.html
+++ b/versions/0.11.0.rc3/api/perl/module.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/perl/ndarray.html
+++ b/versions/0.11.0.rc3/api/perl/ndarray.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/perl/symbol.html
+++ b/versions/0.11.0.rc3/api/perl/symbol.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/python/autograd.html
+++ b/versions/0.11.0.rc3/api/python/autograd.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/python/callback.html
+++ b/versions/0.11.0.rc3/api/python/callback.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/python/gluon.html
+++ b/versions/0.11.0.rc3/api/python/gluon.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/python/image.html
+++ b/versions/0.11.0.rc3/api/python/image.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/python/index.html
+++ b/versions/0.11.0.rc3/api/python/index.html
@@ -138,6 +138,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/python/io.html
+++ b/versions/0.11.0.rc3/api/python/io.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/python/kvstore.html
+++ b/versions/0.11.0.rc3/api/python/kvstore.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/python/metric.html
+++ b/versions/0.11.0.rc3/api/python/metric.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/python/model.html
+++ b/versions/0.11.0.rc3/api/python/model.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/python/module.html
+++ b/versions/0.11.0.rc3/api/python/module.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/python/ndarray.html
+++ b/versions/0.11.0.rc3/api/python/ndarray.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/python/optimization.html
+++ b/versions/0.11.0.rc3/api/python/optimization.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/python/rnn.html
+++ b/versions/0.11.0.rc3/api/python/rnn.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/python/symbol.html
+++ b/versions/0.11.0.rc3/api/python/symbol.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/python/symbol_in_pictures.html
+++ b/versions/0.11.0.rc3/api/python/symbol_in_pictures.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/r/index.html
+++ b/versions/0.11.0.rc3/api/r/index.html
@@ -138,6 +138,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/scala/index.html
+++ b/versions/0.11.0.rc3/api/scala/index.html
@@ -138,6 +138,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/scala/io.html
+++ b/versions/0.11.0.rc3/api/scala/io.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/scala/kvstore.html
+++ b/versions/0.11.0.rc3/api/scala/kvstore.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/scala/model.html
+++ b/versions/0.11.0.rc3/api/scala/model.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/scala/module.html
+++ b/versions/0.11.0.rc3/api/scala/module.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/scala/ndarray.html
+++ b/versions/0.11.0.rc3/api/scala/ndarray.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/scala/symbol.html
+++ b/versions/0.11.0.rc3/api/scala/symbol.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/api/scala/symbol_in_pictures.html
+++ b/versions/0.11.0.rc3/api/scala/symbol_in_pictures.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/architecture/index.html
+++ b/versions/0.11.0.rc3/architecture/index.html
@@ -138,6 +138,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/architecture/note_data_loading.html
+++ b/versions/0.11.0.rc3/architecture/note_data_loading.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/architecture/note_engine.html
+++ b/versions/0.11.0.rc3/architecture/note_engine.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/architecture/note_memory.html
+++ b/versions/0.11.0.rc3/architecture/note_memory.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/architecture/overview.html
+++ b/versions/0.11.0.rc3/architecture/overview.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/architecture/program_model.html
+++ b/versions/0.11.0.rc3/architecture/program_model.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/architecture/release_note_0_9.html
+++ b/versions/0.11.0.rc3/architecture/release_note_0_9.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/architecture/rnn_interface.html
+++ b/versions/0.11.0.rc3/architecture/rnn_interface.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/community/contribute.html
+++ b/versions/0.11.0.rc3/community/contribute.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/community/index.html
+++ b/versions/0.11.0.rc3/community/index.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/community/mxnet_channels.html
+++ b/versions/0.11.0.rc3/community/mxnet_channels.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/genindex.html
+++ b/versions/0.11.0.rc3/genindex.html
@@ -137,6 +137,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="./get_started/install.html">Install</a>
 <a class="main-nav-link" href="./tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="./gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="./how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/get_started/amazonlinux_setup.html
+++ b/versions/0.11.0.rc3/get_started/amazonlinux_setup.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/get_started/build_from_source.html
+++ b/versions/0.11.0.rc3/get_started/build_from_source.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/get_started/centos_setup.html
+++ b/versions/0.11.0.rc3/get_started/centos_setup.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/get_started/index.html
+++ b/versions/0.11.0.rc3/get_started/index.html
@@ -138,6 +138,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/get_started/install.html
+++ b/versions/0.11.0.rc3/get_started/install.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/get_started/osx_setup.html
+++ b/versions/0.11.0.rc3/get_started/osx_setup.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/get_started/raspbian_setup.html
+++ b/versions/0.11.0.rc3/get_started/raspbian_setup.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/get_started/tx2_setup.html
+++ b/versions/0.11.0.rc3/get_started/tx2_setup.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/get_started/ubuntu_setup.html
+++ b/versions/0.11.0.rc3/get_started/ubuntu_setup.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/get_started/why_mxnet.html
+++ b/versions/0.11.0.rc3/get_started/why_mxnet.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/get_started/windows_setup.html
+++ b/versions/0.11.0.rc3/get_started/windows_setup.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/gluon/index.html
+++ b/versions/0.11.0.rc3/gluon/index.html
@@ -62,7 +62,7 @@
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
 <ul class="dropdown-menu" id="package-dropdown-menu">
-<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
 <li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
 </ul>
 </span>
@@ -166,10 +166,9 @@
 <div class="content">
   <div class="section" id="about-gluon">
 <span id="about-gluon"></span><h1>About Gluon<a class="headerlink" href="#about-gluon" title="Permalink to this headline">¶</a></h1>
-<p>MXNet’s Gluon library provides a high-level interface that makes it easy to prototype, train, and deploy deep learning models. It offers higher-level abstractions for predefined layers, loss functions, and optimizers and provides the flexibility of imperative frameworks, which are more intuitive to work with and easier to debug. In addition, it enables building dynamic neural networks on the fly. When speed becomes more important than flexibility, Gluon can also compile your networks with a single line of code, offering optimized performance and memory usage. You can easily get started with the Gluon interface using <a href="http://gluon.mxnet.io/">this extensive set of tutorials, documentation, and examples.</a></p>
+<p>The new Gluon interface is available as a library in Apache MXNet and allows developers of all skill levels to prototype, build, and train deep learning models. This interface greatly simplifies the process of creating deep learning models without sacrificing training speed. You can easily get started with the Gluon interface using <a href="http://gluon.mxnet.io/">this extensive set of tutorials, documentation, and examples.</a></p>
 
-<!-- START - Linux Python CPU Installation Instructions -->
-<strong>Here is a bit more on what Gluon’s four major advantages:</strong>
+<strong>Here are Gluon’s four major advantages:</strong>
 <p>
 <p><strong>Simple, Easy-to-Understand Code</strong></p>
 <p>In Gluon, neural networks can be defined using simple, clear, concise code – this is easier to learn and understand. You get a set of plug-and-play neural network building blocks, including predefined layers, optimizers, and initializers. These abstract away many of the complicated underlying implementation details. Below you see that you can define a neural network with just a few lines of code:</p>

--- a/versions/0.11.0.rc3/gluon/index.html
+++ b/versions/0.11.0.rc3/gluon/index.html
@@ -5,12 +5,12 @@
 <meta charset="utf-8"/>
 <meta content="IE=edge" http-equiv="X-UA-Compatible"/>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
-<title>Tutorials — mxnet  documentation</title>
+<title>Installing MXNet — mxnet  documentation</title>
 <link crossorigin="anonymous" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" rel="stylesheet"/>
 <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" rel="stylesheet"/>
-<link href="../_static/basic.css" rel="stylesheet" type="text/css">
-<link href="../_static/pygments.css" rel="stylesheet" type="text/css">
-<link href="../_static/mxnet.css" rel="stylesheet" type="text/css"/>
+<link href="../_static/basic.css" rel="stylesheet" type="text/css"/>
+<link href="../_static/pygments.css" rel="stylesheet" type="text/css"/>
+<link href="../_static/mxnet.css" rel="stylesheet" type="text/css">
 <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
@@ -48,10 +48,8 @@
 <!-- -->
 <!-- <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script> -->
 <!-- -->
-<link href="basic/ndarray.html" rel="next" title="NDArray - Imperative tensor operations on CPU/GPU">
-<link href="../architecture/index.html" rel="prev" title="MXNet Architecture"/>
-<link href="https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/mxnet-icon.png" rel="icon" type="image/png"/>
-</link></link></link></head>
+<link href="https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/mxnet-icon.png" rel="icon" type="image/png">
+</link></link></head>
 <body role="document"><div class="navbar navbar-fixed-top">
 <div class="container" id="navContainer">
 <div class="innder" id="header-inner">
@@ -83,7 +81,7 @@
 <a class="main-nav-link" href="../architecture/index.html">Architecture</a>
 <!-- <a class="main-nav-link" href="../community/index.html">Community</a> -->
 <a class="main-nav-link" href="https://github.com/dmlc/mxnet">Github</a>
-<span id="dropdown-menu-position-anchor-version" style="position: relative"><a href="#" class="main-nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="true">Versions(0.11.0)<span class="caret"></span></a><ul id="package-dropdown-menu" class="dropdown-menu"><li><a class="main-nav-link" href=https://mxnet.incubator.apache.org/>0.11.0</a></li><li><a class="main-nav-link" href=https://mxnet.incubator.apache.org/versions/0.11.0.rc3/index.html>0.11.0.rc3</a></li><li><a class="main-nav-link" href=https://mxnet.incubator.apache.org/versions/master/index.html>master</a></li></ul></span></nav>
+<span id="dropdown-menu-position-anchor-version" style="position: relative"><a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Versions(0.11.0)<span class="caret"></span></a><ul class="dropdown-menu" id="package-dropdown-menu"><li><a class="main-nav-link" href="https://mxnet.incubator.apache.org/">0.11.0</a></li><li><a class="main-nav-link" href="https://mxnet.incubator.apache.org/versions/0.11.0.rc3/index.html">0.11.0.rc3</a></li><li><a class="main-nav-link" href="https://mxnet.incubator.apache.org/versions/master/index.html">master</a></li></ul></span></nav>
 <script> function getRootPath(){ return "../" } </script>
 <div class="burgerIcon dropdown">
 <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button">☰</a>
@@ -110,7 +108,7 @@
 </li>
 <li><a href="../architecture/index.html">Architecture</a></li>
 <li><a class="main-nav-link" href="https://github.com/dmlc/mxnet">Github</a></li>
-<li id="dropdown-menu-position-anchor-version-mobile" class="dropdown-submenu" style="position: relative"><a href="#" tabindex="-1">Versions(0.11.0)</a><ul class="dropdown-menu"><li><a tabindex="-1" href=https://mxnet.incubator.apache.org/>0.11.0</a></li><li><a tabindex="-1" href=https://mxnet.incubator.apache.org/versions/0.11.0.rc3/index.html>0.11.0.rc3</a></li><li><a tabindex="-1" href=https://mxnet.incubator.apache.org/versions/master/index.html>master</a></li></ul></li></ul>
+<li class="dropdown-submenu" id="dropdown-menu-position-anchor-version-mobile" style="position: relative"><a href="#" tabindex="-1">Versions(0.11.0)</a><ul class="dropdown-menu"><li><a href="https://mxnet.incubator.apache.org/" tabindex="-1">0.11.0</a></li><li><a href="https://mxnet.incubator.apache.org/versions/0.11.0.rc3/index.html" tabindex="-1">0.11.0.rc3</a></li><li><a href="https://mxnet.incubator.apache.org/versions/master/index.html" tabindex="-1">master</a></li></ul></li></ul>
 </div>
 <div class="plusIcon dropdown">
 <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button"><span aria-hidden="true" class="glyphicon glyphicon-plus"></span></a>
@@ -122,8 +120,8 @@
 <i class="glyphicon glyphicon-search"></i>
 <input class="form-control" name="q" placeholder="Search" type="text"/>
 </div>
-<input name="check_keywords" type="hidden" value="yes">
-<input name="area" type="hidden" value="default"/>
+<input name="check_keywords" type="hidden" value="yes"/>
+<input name="area" type="hidden" value="default">
 </input></form>
 <div id="search-preview"></div>
 </div>
@@ -152,7 +150,7 @@
 <div class="row">
 <div aria-label="main navigation" class="sphinxsidebar leftsidebar" role="navigation">
 <div class="sphinxsidebarwrapper">
-<ul class="current">
+<ul>
 <li class="toctree-l1"><a class="reference internal" href="../api/python/index.html">Python Documents</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../api/r/index.html">R Documents</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../api/julia/index.html">Julia Documents</a></li>
@@ -161,67 +159,58 @@
 <li class="toctree-l1"><a class="reference internal" href="../api/perl/index.html">Perl Documents</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../how_to/index.html">HowTo Documents</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../architecture/index.html">System Documents</a></li>
-<li class="toctree-l1 current"><a class="current reference internal" href="">Tutorials</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="#python">Python</a><ul>
-<li class="toctree-l3"><a class="reference internal" href="#basic">Basic</a><ul>
-<li class="toctree-l4"><a class="reference internal" href="basic/ndarray.html">NDArray - Imperative tensor operations on CPU/GPU</a></li>
-<li class="toctree-l4"><a class="reference internal" href="basic/symbol.html">Symbol - Neural network graphs and auto-differentiation</a></li>
-<li class="toctree-l4"><a class="reference internal" href="basic/module.html">Module - Neural network training and inference</a></li>
-<li class="toctree-l4"><a class="reference internal" href="basic/data.html">Iterators - Loading data</a></li>
-</ul>
-</li>
-<li class="toctree-l3"><a class="reference internal" href="#training-and-inference">Training and Inference</a><ul>
-<li class="toctree-l4"><a class="reference internal" href="python/linear-regression.html">Linear Regression</a></li>
-<li class="toctree-l4"><a class="reference internal" href="python/mnist.html">Handwritten Digit Recognition</a></li>
-<li class="toctree-l4"><a class="reference internal" href="python/predict_image.html">Predict with pre-trained models</a></li>
-<li class="toctree-l4"><a class="reference internal" href="vision/large_scale_classification.html">Large Scale Image Classification</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li class="toctree-l2"><a class="reference internal" href="#contributing-tutorials">Contributing Tutorials</a></li>
-</ul>
-</li>
+<li class="toctree-l1"><a class="reference internal" href="../tutorials/index.html">Tutorials</a></li>
 </ul>
 </div>
 </div>
 <div class="content">
-<div class="section" id="tutorials">
-<span id="tutorials"></span><h1>Tutorials<a class="headerlink" href="#tutorials" title="Permalink to this headline">¶</a></h1>
-<p>These tutorials introduce a few fundamental concepts in deep learning and how to implement them in <em>MXNet</em>. The <em>Basics</em> section contains tutorials on manipulating arrays, building networks, loading/preprocessing data, etc. The <em>Training and Inference</em> section talks about implementing Linear Regression, training a Handwritten digit classifier using MLP and CNN, running inferences using a pre-trained model, and lastly, efficiently training a large scale image classifier.</p>
-<p><strong>Note:</strong> We are working on a set of tutorials for the new imperative interface called Gluon. A preview version is hosted at <a class="reference external" href="http://gluon.mxnet.io">gluon.mxnet.io</a>.</p>
-<div class="section" id="python">
-<span id="python"></span><h2>Python<a class="headerlink" href="#python" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="basic">
-<span id="basic"></span><h3>Basic<a class="headerlink" href="#basic" title="Permalink to this headline">¶</a></h3>
-<div class="toctree-wrapper compound">
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="basic/ndarray.html">NDArray - Imperative tensor operations on CPU/GPU</a></li>
-<li class="toctree-l1"><a class="reference internal" href="basic/symbol.html">Symbol - Neural network graphs and auto-differentiation</a></li>
-<li class="toctree-l1"><a class="reference internal" href="basic/module.html">Module - Neural network training and inference</a></li>
-<li class="toctree-l1"><a class="reference internal" href="basic/data.html">Iterators - Loading data</a></li>
-</ul>
+  <div class="section" id="about-gluon">
+<span id="about-gluon"></span><h1>About Gluon<a class="headerlink" href="#about-gluon" title="Permalink to this headline">¶</a></h1>
+<p>MXNet’s Gluon library provides a high-level interface that makes it easy to prototype, train, and deploy deep learning models. It offers higher-level abstractions for predefined layers, loss functions, and optimizers and provides the flexibility of imperative frameworks, which are more intuitive to work with and easier to debug. In addition, it enables building dynamic neural networks on the fly. When speed becomes more important than flexibility, Gluon can also compile your networks with a single line of code, offering optimized performance and memory usage. You can easily get started with the Gluon interface using <a href="http://gluon.mxnet.io/">this extensive set of tutorials, documentation, and examples.</a></p>
+
+<!-- START - Linux Python CPU Installation Instructions -->
+<strong>Here is a bit more on what Gluon’s four major advantages:</strong>
+<p>
+<p><strong>Simple, Easy-to-Understand Code</strong></p>
+<p>In Gluon, neural networks can be defined using simple, clear, concise code – this is easier to learn and understand. You get a set of plug-and-play neural network building blocks, including predefined layers, optimizers, and initializers. These abstract away many of the complicated underlying implementation details. Below you see that you can define a neural network with just a few lines of code:</p>
+<div class="highlight-bash"><div class="highlight"><pre><span></span><span class="nv">net</span> <span class="o">=</span> gluon.nn.Sequential<span class="o">()</span>
+<span class="c1"># When instantiated, Sequential stores a chain of neural network layers. </span>
+<span class="c1"># Once presented with data, Sequential executes each layer in turn, using </span>
+<span class="c1"># the output of one layer as the input for the next</span>
+with net.name_scope<span class="o">()</span>:
+    net.add<span class="o">(</span>gluon.nn.Dense<span class="o">(</span><span class="m">256</span>, <span class="nv">activation</span><span class="o">=</span><span class="s2">&quot;relu&quot;</span><span class="o">))</span> <span class="c1"># 1st layer (256 nodes)</span>
+    net.add<span class="o">(</span>gluon.nn.Dense<span class="o">(</span><span class="m">256</span>, <span class="nv">activation</span><span class="o">=</span><span class="s2">&quot;relu&quot;</span><span class="o">))</span> <span class="c1"># 2nd hidden layer</span>
+    net.add<span class="o">(</span>gluon.nn.Dense<span class="o">(</span>num_outputs<span class="o">))</span>
+</pre></div>
+</div>
+
+<p><strong>Flexible, Imperative Structure</strong></p>
+<p>The Gluon interface supports a fully imperative way of working with neural networks, offering more familiarity and flexibility. Many familiar programming languages like Python are imperative, and imperative programs execute code line by line versus waiting for a code compilation step prior to executing any code. With Gluon, you can easily experiment and prototype with neural networks. Debugging is also easier with Gluon because you can identify the exact line of code causing an issue. Central to enabling this are the MXNet <em>autograd</em> package and the Gluon trainer method. You can define a model training algorithm that consists of a for loop, using <em>autograd</em> to automatically calculate derivatives of the model’s parameters and <em>trainer</em> to optimize them.</p>
+<p><strong>Dynamic Graphs</strong></p>
+<p>In certain scenarios, the neural network model may need to change in shape and size during model training. This is necessary in particular when the data fed into the neural network is variable, which is common in Natural Language Processing (NLP) where each sentence inputted can be of different length. With Gluon, neural network definition can be dynamic, meaning you can build it on the fly, with any structure you want, and using any of Python’s native control flow. In the below code snippet, you can see how to incorporate a loop in each forward iteration of model training.</p>
+<div class="highlight-bash"><div class="highlight"><pre><span></span>def forward<span class="o">(</span>self, F, inputs, tree<span class="o">)</span>:
+    <span class="nv">children_outputs</span> <span class="o">=</span> <span class="o">[</span>self.forward<span class="o">(</span>F, inputs, child<span class="o">)</span>
+                        <span class="k">for</span> child in tree.children<span class="o">]</span>
+    <span class="c1">#Recursively builds the neural network based on each input sentence’s</span>
+    <span class="c1">#syntactic structure during the model definition and training process</span>
+    …
+</pre></div>
+</div>
+<p><strong>High Performance</strong></p>
+<p>When speed becomes more important than flexibility, the Gluon interface enables you to easily cache the neural network model to achieve high performance. This only requires a small tweak when you set up your neural network – this is after you are done with your prototype and ready to test it on a larger dataset. Instead of using <em>Sequential</em> (as shown above) to stack the neural network layers, you must use <em>HybridSequential</em>. Its functionality is the same as <em>Sequential</em>, but it lets you call down to the underlying optimized engine to express some or all of your model’s architecture.</p>
+<div class="highlight-bash"><div class="highlight"><pre><span></span><span class="nv">net</span> <span class="o">=</span> nn.HybridSequential<span class="o">()</span>
+with net.name_scope<span class="o">()</span>:
+    net.add<span class="o">(</span>nn.Dense<span class="o">(</span><span class="m">256</span>, <span class="nv">activation</span><span class="o">=</span><span class="s2">&quot;relu&quot;</span><span class="o">))</span>
+    net.add<span class="o">(</span>nn.Dense<span class="o">(</span><span class="m">128</span>, <span class="nv">activation</span><span class="o">=</span><span class="s2">&quot;relu&quot;</span><span class="o">))</span>
+    net.add<span class="o">(</span>nn.Dense<span class="o">(</span><span class="m">2</span><span class="o">))</span>
+</pre></div>
+</div>
+<p>Next, to compile and optimize the HybridSequential, we can then call its hybridize method:</p>
+<div class="highlight-bash"><div class="highlight"><pre><span></span>net.hybridize<span class="o">()</span>
+</pre></div>
 </div>
 </div>
-<div class="section" id="training-and-inference">
-<span id="training-and-inference"></span><h3>Training and Inference<a class="headerlink" href="#training-and-inference" title="Permalink to this headline">¶</a></h3>
-<div class="toctree-wrapper compound">
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="python/linear-regression.html">Linear Regression</a></li>
-<li class="toctree-l1"><a class="reference internal" href="python/mnist.html">Handwritten Digit Recognition</a></li>
-<li class="toctree-l1"><a class="reference internal" href="python/predict_image.html">Predict with pre-trained models</a></li>
-<li class="toctree-l1"><a class="reference internal" href="vision/large_scale_classification.html">Large Scale Image Classification</a></li>
-</ul>
-</div>
-<p><br/>
-More tutorials and examples are available in the GitHub <a class="reference external" href="https://github.com/dmlc/mxnet/tree/master/example">repository</a>.</p>
-</div>
-</div>
-<div class="section" id="contributing-tutorials">
-<span id="contributing-tutorials"></span><h2>Contributing Tutorials<a class="headerlink" href="#contributing-tutorials" title="Permalink to this headline">¶</a></h2>
-<p>Want to contribute an MXNet tutorial? To get started, download the <a class="reference external" href="https://github.com/dmlc/mxnet/tree/master/example/MXNetTutorialTemplate.ipynb">tutorial template</a>.</p>
-</div>
-</div>
+
 <div class="container">
 <div class="footer">
 <p> </p>
@@ -232,15 +221,9 @@ More tutorials and examples are available in the GitHub <a class="reference exte
 <div class="sphinxsidebarwrapper">
 <h3><a href="../index.html">Table Of Contents</a></h3>
 <ul>
-<li><a class="reference internal" href="#">Tutorials</a><ul>
-<li><a class="reference internal" href="#python">Python</a><ul>
-<li><a class="reference internal" href="#basic">Basic</a></li>
-<li><a class="reference internal" href="#training-and-inference">Training and Inference</a></li>
-</ul>
-</li>
-<li><a class="reference internal" href="#contributing-tutorials">Contributing Tutorials</a></li>
-</ul>
-</li>
+<li><a class="reference internal" href="#">Installing MXNet</a></li>
+<li><a class="reference internal" href="#validate-mxnet-installation">Validate MXNet Installation</a></li>
+<li><a class="reference internal" href="#download-source-package">Download Source Package</a></li>
 </ul>
 </div>
 </div>

--- a/versions/0.11.0.rc3/how_to/bucketing.html
+++ b/versions/0.11.0.rc3/how_to/bucketing.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/how_to/caffe.html
+++ b/versions/0.11.0.rc3/how_to/caffe.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/how_to/cloud.html
+++ b/versions/0.11.0.rc3/how_to/cloud.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/how_to/develop_and_hack.html
+++ b/versions/0.11.0.rc3/how_to/develop_and_hack.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/how_to/env_var.html
+++ b/versions/0.11.0.rc3/how_to/env_var.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/how_to/faq.html
+++ b/versions/0.11.0.rc3/how_to/faq.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/how_to/finetune.html
+++ b/versions/0.11.0.rc3/how_to/finetune.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/how_to/index.html
+++ b/versions/0.11.0.rc3/how_to/index.html
@@ -138,6 +138,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/how_to/model_parallel_lstm.html
+++ b/versions/0.11.0.rc3/how_to/model_parallel_lstm.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/how_to/multi_devices.html
+++ b/versions/0.11.0.rc3/how_to/multi_devices.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/how_to/new_op.html
+++ b/versions/0.11.0.rc3/how_to/new_op.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/how_to/nnpack.html
+++ b/versions/0.11.0.rc3/how_to/nnpack.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/how_to/perf.html
+++ b/versions/0.11.0.rc3/how_to/perf.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/how_to/recordio.html
+++ b/versions/0.11.0.rc3/how_to/recordio.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/how_to/s3_integration.html
+++ b/versions/0.11.0.rc3/how_to/s3_integration.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/how_to/smart_device.html
+++ b/versions/0.11.0.rc3/how_to/smart_device.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/how_to/torch.html
+++ b/versions/0.11.0.rc3/how_to/torch.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/how_to/visualize_graph.html
+++ b/versions/0.11.0.rc3/how_to/visualize_graph.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/index.html
+++ b/versions/0.11.0.rc3/index.html
@@ -138,7 +138,7 @@ Previous Navbar Layout End -->
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
 <ul class="dropdown-menu" id="package-dropdown-menu">
-<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="./gluon/index.html">About</a></li>
 <li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
 </ul>
 </span>

--- a/versions/0.11.0.rc3/index.html
+++ b/versions/0.11.0.rc3/index.html
@@ -135,6 +135,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="./get_started/install.html">Install</a>
 <a class="main-nav-link" href="./tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="./how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/model_zoo/index.html
+++ b/versions/0.11.0.rc3/model_zoo/index.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/py-modindex.html
+++ b/versions/0.11.0.rc3/py-modindex.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="./get_started/install.html">Install</a>
 <a class="main-nav-link" href="./tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="./gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="./how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/search.html
+++ b/versions/0.11.0.rc3/search.html
@@ -142,6 +142,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="./get_started/install.html">Install</a>
 <a class="main-nav-link" href="./tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="./gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="./how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/basic/data.html
+++ b/versions/0.11.0.rc3/tutorials/basic/data.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/basic/image_io.html
+++ b/versions/0.11.0.rc3/tutorials/basic/image_io.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/basic/module.html
+++ b/versions/0.11.0.rc3/tutorials/basic/module.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/basic/ndarray.html
+++ b/versions/0.11.0.rc3/tutorials/basic/ndarray.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/basic/record_io.html
+++ b/versions/0.11.0.rc3/tutorials/basic/record_io.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/basic/symbol.html
+++ b/versions/0.11.0.rc3/tutorials/basic/symbol.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/c++/basics.html
+++ b/versions/0.11.0.rc3/tutorials/c++/basics.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/embedded/wine_detector.html
+++ b/versions/0.11.0.rc3/tutorials/embedded/wine_detector.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/general_ml/recommendation_systems.html
+++ b/versions/0.11.0.rc3/tutorials/general_ml/recommendation_systems.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/gluon/autograd.html
+++ b/versions/0.11.0.rc3/tutorials/gluon/autograd.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/gluon/customop.html
+++ b/versions/0.11.0.rc3/tutorials/gluon/customop.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/gluon/gluon.html
+++ b/versions/0.11.0.rc3/tutorials/gluon/gluon.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/gluon/hybrid.html
+++ b/versions/0.11.0.rc3/tutorials/gluon/hybrid.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/gluon/mnist.html
+++ b/versions/0.11.0.rc3/tutorials/gluon/mnist.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/gluon/ndarray.html
+++ b/versions/0.11.0.rc3/tutorials/gluon/ndarray.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/index.html
+++ b/versions/0.11.0.rc3/tutorials/index.html
@@ -138,6 +138,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/nlp/cnn.html
+++ b/versions/0.11.0.rc3/tutorials/nlp/cnn.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/nlp/nce_loss.html
+++ b/versions/0.11.0.rc3/tutorials/nlp/nce_loss.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/nlp/rnn.html
+++ b/versions/0.11.0.rc3/tutorials/nlp/rnn.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/python/kvstore.html
+++ b/versions/0.11.0.rc3/tutorials/python/kvstore.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/python/linear-regression.html
+++ b/versions/0.11.0.rc3/tutorials/python/linear-regression.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/python/matrix_factorization.html
+++ b/versions/0.11.0.rc3/tutorials/python/matrix_factorization.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/python/mnist.html
+++ b/versions/0.11.0.rc3/tutorials/python/mnist.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/python/predict_image.html
+++ b/versions/0.11.0.rc3/tutorials/python/predict_image.html
@@ -139,6 +139,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/r/CallbackFunctionTutorial.html
+++ b/versions/0.11.0.rc3/tutorials/r/CallbackFunctionTutorial.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/r/CustomIteratorTutorial.html
+++ b/versions/0.11.0.rc3/tutorials/r/CustomIteratorTutorial.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/r/CustomLossFunction.html
+++ b/versions/0.11.0.rc3/tutorials/r/CustomLossFunction.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/r/charRnnModel.html
+++ b/versions/0.11.0.rc3/tutorials/r/charRnnModel.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/r/classifyRealImageWithPretrainedModel.html
+++ b/versions/0.11.0.rc3/tutorials/r/classifyRealImageWithPretrainedModel.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/r/fiveMinutesNeuralNetwork.html
+++ b/versions/0.11.0.rc3/tutorials/r/fiveMinutesNeuralNetwork.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/r/mnistCompetition.html
+++ b/versions/0.11.0.rc3/tutorials/r/mnistCompetition.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/r/ndarray.html
+++ b/versions/0.11.0.rc3/tutorials/r/ndarray.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/r/symbol.html
+++ b/versions/0.11.0.rc3/tutorials/r/symbol.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/scala/char_lstm.html
+++ b/versions/0.11.0.rc3/tutorials/scala/char_lstm.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/scala/mnist.html
+++ b/versions/0.11.0.rc3/tutorials/scala/mnist.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/scala/mxnet_scala_on_intellij.html
+++ b/versions/0.11.0.rc3/tutorials/scala/mxnet_scala_on_intellij.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/speech_recognition/baidu_warp_ctc.html
+++ b/versions/0.11.0.rc3/tutorials/speech_recognition/baidu_warp_ctc.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/speech_recognition/speech_lstm.html
+++ b/versions/0.11.0.rc3/tutorials/speech_recognition/speech_lstm.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/unsupervised_learning/auto_encoders.html
+++ b/versions/0.11.0.rc3/tutorials/unsupervised_learning/auto_encoders.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/unsupervised_learning/gan.html
+++ b/versions/0.11.0.rc3/tutorials/unsupervised_learning/gan.html
@@ -136,6 +136,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/0.11.0.rc3/tutorials/vision/large_scale_classification.html
+++ b/versions/0.11.0.rc3/tutorials/vision/large_scale_classification.html
@@ -138,6 +138,13 @@ Previous Navbar Layout End -->
 <nav class="nav-bar" id="main-nav">
 <a class="main-nav-link" href="../../get_started/install.html">Install</a>
 <a class="main-nav-link" href="../../tutorials/index.html">Tutorials</a>
+<span id="dropdown-menu-position-anchor">
+<a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Gluon <span class="caret"></span></a>
+<ul class="dropdown-menu" id="package-dropdown-menu">
+<li><a class="main-nav-link" href="../../gluon/index.html">About</a></li>
+<li><a class="main-nav-link" href="http://gluon.mxnet.io/">The Straight Dope</a></li>
+</ul>
+</span>
 <a class="main-nav-link" href="../../how_to/index.html">How To</a>
 <span id="dropdown-menu-position-anchor">
 <a aria-expanded="true" aria-haspopup="true" class="main-nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">API <span class="caret"></span></a>

--- a/versions/master/faq/bucketing.html
+++ b/versions/master/faq/bucketing.html
@@ -8,8 +8,8 @@
 <title>Bucketing in MXNet — mxnet  documentation</title>
 <link crossorigin="anonymous" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" rel="stylesheet"/>
 <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" rel="stylesheet"/>
-<link href="../_static/basic.css" rel="stylesheet" type="text/css">
-<link href="../_static/pygments.css" rel="stylesheet" type="text/css">
+<link href="../_static/basic.css" rel="stylesheet" type="text/css"/>
+<link href="../_static/pygments.css" rel="stylesheet" type="text/css"/>
 <link href="../_static/mxnet.css" rel="stylesheet" type="text/css"/>
 <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
@@ -49,7 +49,7 @@
 <!-- <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script> -->
 <!-- -->
 <link href="https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/mxnet-icon.png" rel="icon" type="image/png"/>
-</link></link></head>
+</head>
 <body background="https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/mxnet-background.png" role="document">
 <div class="content-block"><div class="navbar navbar-fixed-top">
 <div class="container" id="navContainer">
@@ -145,9 +145,9 @@
 <i class="glyphicon glyphicon-search"></i>
 <input class="form-control" name="q" placeholder="Search" type="text"/>
 </div>
-<input name="check_keywords" type="hidden" value="yes">
+<input name="check_keywords" type="hidden" value="yes"/>
 <input name="area" type="hidden" value="default"/>
-</input></form>
+</form>
 <div id="search-preview"></div>
 </div>
 <div id="searchIcon">
@@ -185,7 +185,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../api/c++/index.html">C++ Documents</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../api/scala/index.html">Scala Documents</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../api/perl/index.html">Perl Documents</a></li>
-<li class="toctree-l1"><a class="reference internal" href="index.html">HowTo Documents</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://mxnet.incubator.apache.org/versions/master/how_to/index.md">HowTo Documents</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../architecture/index.html">System Documents</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../tutorials/index.html">Tutorials</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../community/index.html">Community</a></li>


### PR DESCRIPTION
This was an urgent request for the Gluon Live launch on October 9th. This directive came from the PM to get this added to v011 live website before Oct 9th.

Since we are not doing builds on v011, I had to do these changes directly to the builds. All the files here are static index.html changes and a new About page has been added for "Gluon".

Locally tested the menu appearance and its looking good and confirmed there are no broken links with this in push.

Thanks