### PR TITLE
fixed Apache MxNet tag line and typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,11 +183,7 @@
 <div class="row">
 <div class="col-lg-12">
 <div class="col-sm-6 col-xs-12" id="banner-title"><span>Apache MXNet</span>
-<p id="landing-title">is a flexible and efficient library for deep learning.</p>
-<p id="intro">
-                Building a high-performance deep learning library requires many system-level design decisions. In this design note, we share the rationale for the specific 
-                choices made when designing MXNet. We imagine that these insights may be useful to both deep learning practitioners and builders of other deep learning systems.
-            </p>
+<p id="landing-title">flexible and efficient library for deep learning</p>
 <div id="landing-btn-blk">
 <div id="install_blk">
 <a href="install/index.html" id="install_btn">Install</a>
@@ -238,7 +234,7 @@
 <div class="col-lg-4 col-sm-12" id="example-blk">
 <span class="glyphicon glyphicon-list-alt"></span>
 <h2>Examples</h2>
-<p>Explore projects from simple demos, exmaples, tutorials to state-of-the-art research.</p>
+<p>Explore projects from simple demos, examples, tutorials to state-of-the-art research.</p>
 <div class="util-btn">
 <a href="https://github.com/dmlc/mxnet/tree/master/example" id="example-link">MXNet examples</a>
 </div>


### PR DESCRIPTION
## Description ##
- Removed the long description in the mainpage.
- Shortened the tag line.
- Fixed typo exmaples to examples