### PR TITLE
Modify Scala web site linking to GitHub with package name

### DIFF
--- a/api/scala/index.html
+++ b/api/scala/index.html
@@ -206,8 +206,8 @@
 <li class="toctree-l2"><a class="reference internal" href="#resources">Resources</a><ul>
 <li class="toctree-l3"><a class="reference external" href="https://mxnet.incubator.apache.org/api/scala/docs/index.html">MXNet Scala API Documentation</a></li>
 <li class="toctree-l3"><a class="reference external" href="https://mxnet.incubator.apache.org/tutorials/scala/mnist.html">Handwritten Digit Classification in Scala</a></li>
-<li class="toctree-l3"><a class="reference external" href="https://github.com/dmlc/mxnet/blob/master/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/neuralstyle/NeuralStyle.scala">Neural Style in Scala on MXNet</a></li>
-<li class="toctree-l3"><a class="reference external" href="https://github.com/dmlc/mxnet/tree/master/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples">More Scala Examples</a></li>
+<li class="toctree-l3"><a class="reference external" href="https://github.com/dmlc/mxnet/blob/master/scala-package/examples/src/main/scala/org/apache/mxnetexamples/neuralstyle/NeuralStyle.scala">Neural Style in Scala on MXNet</a></li>
+<li class="toctree-l3"><a class="reference external" href="https://github.com/dmlc/mxnet/tree/master/scala-package/examples/src/main/scala/org/apache/mxnetexamples">More Scala Examples</a></li>
 </ul>
 </li>
 </ul>
@@ -264,8 +264,8 @@ and apply them to tasks, such as image classification and data science challenge
 <ul>
 <li class="toctree-l1"><a class="reference external" href="https://mxnet.incubator.apache.org/api/scala/docs/index.html">MXNet Scala API Documentation</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://mxnet.incubator.apache.org/tutorials/scala/mnist.html">Handwritten Digit Classification in Scala</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/dmlc/mxnet/blob/master/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/neuralstyle/NeuralStyle.scala">Neural Style in Scala on MXNet</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/dmlc/mxnet/tree/master/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples">More Scala Examples</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/dmlc/mxnet/blob/master/scala-package/examples/src/main/scala/org/apache/mxnetexamples/neuralstyle/NeuralStyle.scala">Neural Style in Scala on MXNet</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/dmlc/mxnet/tree/master/scala-package/examples/src/main/scala/org/apache/mxnetexamples">More Scala Examples</a></li>
 </ul>
 </div>
 </div>


### PR DESCRIPTION
## Description ##
The Scala web site has some links to GitHub which use new package name such that the original links failed.

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
