### PR TITLE
fixed getting_started install.html to point to the latest version of …

### DIFF
--- a/get_started/install.html
+++ b/get_started/install.html
@@ -3,9 +3,10 @@
 <html lang="en">
 <head>
 <meta charset="utf-8"/>
-<meta content="IE=edge" http-equiv="X-UA-Compatible"/>
-<meta content="width=device-width, initial-scale=1" name="viewport"/>
-<title>Installing MXNet — mxnet  documentation</title>
+<meta content="0; url=../install/index.html" http-equiv="refresh"/>
+<title>Page Redirection</title>
+
+<<!-- title>Installing MXNet — mxnet  documentation</title> -->
 <link crossorigin="anonymous" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" rel="stylesheet"/>
 <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" rel="stylesheet"/>
 <link href="../_static/basic.css" rel="stylesheet" type="text/css"/>


### PR DESCRIPTION
Description:
Currently google has cached the url to getting_started/index.html which has old content and points to 0.11.0. Either Google needs to recrawl or we can redirect the url to point to the latest version. I have made changes to redirect URL which will take effect immediately, after the PR is merged.

- [x] Ensure get_started/index.html redirects to install/index.html
- [x] Test for regression and test all versions for install links


