### PR TITLE
Test redirect rule based on referer

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -6,7 +6,8 @@ RewriteOptions AllowNoSlash
 # Set default website version to current stable (v1.6) TODO delete test code and uncomment origin code 
 RewriteCond %{REQUEST_URI} !^/versions/
 RewriteCond %{HTTP_REFERER} !mxnet-beta.staged.apache.org
-Rewriterule ^(.*)$ /versions/1.6/$1 [r=307,L]
+# RewriteRule ^(.*)$ /versions/1.6/$1 [r=307,L]
+RewriteRule ^(.*)$ /features [r=307,L]
 
 # Show file instead of folder for example /api/docs/tutorials.html
 # instead of /api/docs/tutorials/


### PR DESCRIPTION
This PR is for the testing of redirect rules which set website default version on Apache server. 
Expected behavior: when load the website from browser, it will redirect to `/features` url. During navigating within website, no redirect will happen. This is to mock setting website default version redirect behavior.
Origin PR: https://github.com/apache/incubator-mxnet/pull/18738